### PR TITLE
Fix typo

### DIFF
--- a/src/components/common/SEO/index.jsx
+++ b/src/components/common/SEO/index.jsx
@@ -57,7 +57,7 @@ export default ({
 						? localizedTitle
 							? formatMessage({ id: localizedTitle })
 							: title
-						: "Elliot Headless Pacakge"
+						: "Elliot Headless Package"
 				}
 			/>
 			<meta


### PR DESCRIPTION
There was a typo in the `meta` title
